### PR TITLE
Handle empty server response when logged off due to inactivity

### DIFF
--- a/src/imapidle.py
+++ b/src/imapidle.py
@@ -8,14 +8,17 @@ def idle(connection):
     tag = connection._new_tag()
     connection.send("%s IDLE\r\n" % tag)
     response = connection.readline()
-    connection.loop = True
-    if response == '+ idling\r\n':
-        while connection.loop:
-            resp = connection.readline()
-            uid, message = resp[2:-2].split(' ')
-            yield uid, message
-    else:
+    if response != '+ idling\r\n':
         raise Exception("IDLE not handled? : %s" % response)
+    connection.loop = True
+    while connection.loop:
+        try:
+            resp = connection._get_response()
+        except connection.abort:
+            connection.done()
+        else:
+            uid, message = resp.split()[1:]
+            yield uid, message
 
 
 def done(connection):


### PR DESCRIPTION
I am seeing an error when idling on a gmail inbox and the server logs the user out after a period of time. From a close look at the IDLE spec, this is legitimate behavior. Specifically, the stack trace is:

```
Traceback (most recent call last):
  File "imapidle/src/imapidle.py", line 64, in <module>
    for uid, msg in mbox.idle():
  File "imapidle/src/imapidle.py", line 21, in idle
    uid, message = resp[2:-2].split(' ')
ValueError: need more than 1 value to unpack
```

This change adds error handling for the above case. I have been able to idle on a gmail account for multiple days now.

BTW, thanks for this, it has proven to be very useful!
