### PR TITLE
Fix for handling long server responce

### DIFF
--- a/src/imapidle.py
+++ b/src/imapidle.py
@@ -12,7 +12,7 @@ def idle(connection):
     if response == '+ idling\r\n':
         while connection.loop:
             resp = connection.readline()
-            uid, message = resp[2:-2].split(' ')
+            uid, message = resp[2:-2].split(' ', 1)
             yield uid, message
     else:
         raise Exception("IDLE not handled? : %s" % response)


### PR DESCRIPTION
When handle long server response like this:

"\* 29 FETCH (FLAGS () UID 186)\n"

we have an error:

Traceback (most recent call last):
  File "imapidle\src\imapidle.py", line 15, in idle
    uid, message = resp[2:-2].split(' ')
ValueError: too many values to unpack

This small change adds error handling for the above case.
